### PR TITLE
DDP model init on all ranks of main process group

### DIFF
--- a/training/train_fno.py
+++ b/training/train_fno.py
@@ -224,7 +224,7 @@ class FourierNeuralOperator:
         if self.DDP_enabled:
             self.model = DDP(self.model, 
                              device_ids=[self.local_rank],
-                             process_group=self.dp_group,  # default: init_process_group
+                             process_group=None,  # default: init_process_group
                              broadcast_buffers=True
                             )
         torch.cuda.empty_cache()


### PR DESCRIPTION
Even though torch replicates model on all ranks, making code consistent to match the torch execution explicitly 