### PR TITLE
Input Sharding and Precision Debugging 

### DIFF
--- a/config/electrostatic_plasma1d_pic.yaml
+++ b/config/electrostatic_plasma1d_pic.yaml
@@ -79,16 +79,33 @@ eval:
   imgExt: png
   evalDir: eval1D_PIF_4_miniapps
   dim: 1
-  kc : 0.5
   NG : 32
-  T: 60.0
-  dt: 0.05
   Vt: 1
   nParticle: 100000
   Qm : -1
-  alpha: 0.05
-  testCase: weakLandau
-  ref: pic
+  ref: pif
+  
+testCases:
+  bti: 
+    T: 60
+    dt: 0.05
+    kc: 0.21
+    alpha: 0.01
+  tsi:
+    T: 60
+    dt: 0.05
+    kc: 0.5
+    alpha: 0.01
+  weakLandau:
+    T: 60
+    dt: 0.05
+    kc: 0.5
+    alpha: 0.05
+  strongLandau:
+    T: 60
+    dt: 0.05
+    kc: 0.5
+    alpha: 0.5
 
 profile:
   enableProfiler: false

--- a/config/electrostatic_plasma2d_pic.yaml
+++ b/config/electrostatic_plasma2d_pic.yaml
@@ -78,16 +78,38 @@ eval:
   imgExt: png
   evalDir: eval2D_PIF_5_miniapps
   dim: 2
-  kc : 0.21
   NG : 32
-  T: 60.0
-  dt: 0.05
   Vt: 1
   nParticle: 100000
   Qm : -1
-  alpha: 0.01
-  testCase: bti
   ref: pif
+
+testCases:
+  bti: 
+    T: 60
+    dt: 0.05
+    kc: 0.21
+    alpha: 0.01
+  tsi:
+    T: 60
+    dt: 0.05
+    kc: 0.5
+    alpha: 0.01
+  weakLandau:
+    T: 60
+    dt: 0.05
+    kc: 0.5
+    alpha: 0.05
+  strongLandau:
+    T: 60
+    dt: 0.05
+    kc: 0.5
+    alpha: 0.5
+  cyclotron:
+    T: 12
+    dt: 0.01
+    kc: 0.5
+    alpha: 0.01
   
 profile:
   enableProfiler: false

--- a/config/electrostatic_plasma3d_pic.yaml
+++ b/config/electrostatic_plasma3d_pic.yaml
@@ -79,16 +79,38 @@ eval:
   imgExt: png
   evalDir: eval3D_PIF_5_miniapps
   dim: 3
-  kc : 0.21
   NG : 32
-  T: 60.0
-  dt: 0.05
   Vt: 1
   nParticle: 100000
   Qm : -1
-  alpha: 0.01
-  testCase: bti
   ref: pif
+
+testCases:
+  bti: 
+    T: 60
+    dt: 0.05
+    kc: 0.21
+    alpha: 0.01
+  tsi:
+    T: 60
+    dt: 0.05
+    kc: 0.5
+    alpha: 0.01
+  weakLandau:
+    T: 60
+    dt: 0.05
+    kc: 0.5
+    alpha: 0.05
+  strongLandau:
+    T: 60
+    dt: 0.05
+    kc: 0.5
+    alpha: 0.5
+  cyclotron:
+    T: 12
+    dt: 0.01
+    kc: 0.5
+    alpha: 0.01
   
 profile:
   enableProfiler: false

--- a/operator_learning/data/transforms/vandermonde_matrix_free.py
+++ b/operator_learning/data/transforms/vandermonde_matrix_free.py
@@ -8,7 +8,7 @@ class VandermondeTransformMatrixFree:
     def __init__(self, x_positions, kX, x_pos_min=None, x_pos_max=None, 
                  y_positions=None, kY=None, y_pos_min=None, y_pos_max=None,
                  z_positions=None, kZ=None, z_pos_min=None, z_pos_max=None,
-                 dim=1, device='cuda', dtype=torch.float64):
+                 dim=1, device='cuda', dtype=torch.float32):
         self.device = device
         self.dtype = dtype
         assert dim in (1, 2, 3), "dim must be 1 or 2 or 3"

--- a/operator_learning/data/transforms/vandermonde_matrix_free.py
+++ b/operator_learning/data/transforms/vandermonde_matrix_free.py
@@ -5,15 +5,21 @@ class VandermondeTransformMatrixFree:
     """
     Matrix-free 1D/2D/3D Fourier transforms on a nonequispaced lattice.
     """
-    def __init__(self, x_positions, kX, y_positions=None, kY=None,
-                 z_positions=None, kZ=None, dim=1, device='cuda', dtype=torch.float32):
+    def __init__(self, x_positions, kX, x_pos_min=None, x_pos_max=None, 
+                 y_positions=None, kY=None, y_pos_min=None, y_pos_max=None,
+                 z_positions=None, kZ=None, z_pos_min=None, z_pos_max=None,
+                 dim=1, device='cuda', dtype=torch.float64):
         self.device = device
         self.dtype = dtype
         assert dim in (1, 2, 3), "dim must be 1 or 2 or 3"
         self.dim = dim
         self.kX = kX
-        x_positions = x_positions - torch.min(x_positions)
-        self.x_positions = x_positions * 6.28 / torch.max(x_positions)
+        if x_pos_min is None:
+            x_pos_min = torch.min(x_positions) 
+        if x_pos_max is None:
+            x_pos_max = torch.max(x_positions)
+        x_positions = x_positions - x_pos_min              
+        self.x_positions = x_positions * 6.28 /  x_pos_max 
         self.X_ = torch.cat((torch.arange(self.kX, dtype=dtype, device=device), 
                              torch.arange(start=-(self.kX), end=0, dtype=dtype, device=device)), 
                              0)
@@ -22,20 +28,28 @@ class VandermondeTransformMatrixFree:
         self.Fx = torch.exp(-1j * self.X_[None, :, None] * self.x_positions[:, None, :]) #(batchsize, 2*kX, nParticle)
 
         if dim > 1:  
+            if y_pos_min is None:
+                y_pos_min = torch.min(y_positions) 
+            if y_pos_max is None:
+                y_pos_max = torch.max(y_positions)
             self.kY = kY if kY is not None else kX
             self.Y_ = torch.cat((torch.arange(self.kY, dtype=dtype, device=device),
                                  torch.arange(start=-(self.kY), end=0, dtype=dtype, device=device)),
                                  0)
-            y_positions = y_positions - torch.min(y_positions)
-            self.y_positions = y_positions * 6.28 / torch.max(y_positions)
+            y_positions = y_positions - y_pos_min              
+            self.y_positions = y_positions * 6.28 /y_pos_max  
             self.Fy = torch.exp(-1j * self.Y_[None, :, None] * self.y_positions[:, None, :]) #(batchsize, 2*kY, nParticle)
         if dim > 2:
+            if z_pos_min is None:
+                z_pos_min = torch.min(z_positions) 
+            if z_pos_max is None:
+                z_pos_max = torch.max(z_positions)
             self.kZ = kZ if kZ is not None else kX
             self.Z_ = torch.cat((torch.arange(self.kZ, dtype=dtype, device=device),
                                  torch.arange(start=-(self.kZ), end=0, dtype=dtype, device=device)),
                                  0)
-            z_positions = z_positions - torch.min(z_positions)
-            self.z_positions = z_positions * 6.28 / torch.max(z_positions)
+            z_positions = z_positions - z_pos_min                          
+            self.z_positions = z_positions * 6.28 / z_pos_max             
             self.Fz = torch.exp(-1j * self.Z_[None, :, None] * self.z_positions[:, None, :]) #(batchsize, 2*kZ, nParticle)
 
 
@@ -65,7 +79,8 @@ class VandermondeTransformMatrixFree:
     
         out = torch.einsum("bcp,bkp,blp->bckl", data, self.Fx, self.Fy)
         out = out.reshape(self.batch_size, data.shape[1], len(self.X_)*len(self.Y_))
-
+        # print(f'data: {data.dtype}, Fx: {self.Fx.dtype}, Fy: {self.Fy.dtype}, FWD out: {out.dtype}', flush=True)
+       
         return out 
     
     def _inverse_2d(self, data):
@@ -75,6 +90,7 @@ class VandermondeTransformMatrixFree:
         """
         d = data.reshape(self.batch_size, data.shape[1], len(self.X_), len(self.Y_))
         out = torch.einsum("bckl,bkp,blp->bcp", d, torch.conj(self.Fx), torch.conj(self.Fy)) 
+        # print(f'BWD out: {out.dtype}, data: {data.dtype}, Fx: {self.Fx.dtype}, Fy: {self.Fy.dtype}', flush=True)
 
         return out
     

--- a/operator_learning/data/transforms/vandermonde_matrix_free.py
+++ b/operator_learning/data/transforms/vandermonde_matrix_free.py
@@ -19,7 +19,7 @@ class VandermondeTransformMatrixFree:
         if x_pos_max is None:
             x_pos_max = torch.max(x_positions)
         x_positions = x_positions - x_pos_min              
-        self.x_positions = x_positions * 6.28 /  x_pos_max 
+        self.x_positions = x_positions * 2*torch.pi /  x_pos_max 
         self.X_ = torch.cat((torch.arange(self.kX, dtype=dtype, device=device), 
                              torch.arange(start=-(self.kX), end=0, dtype=dtype, device=device)), 
                              0)
@@ -37,7 +37,7 @@ class VandermondeTransformMatrixFree:
                                  torch.arange(start=-(self.kY), end=0, dtype=dtype, device=device)),
                                  0)
             y_positions = y_positions - y_pos_min              
-            self.y_positions = y_positions * 6.28 /y_pos_max  
+            self.y_positions = y_positions * 2*torch.pi /y_pos_max  
             self.Fy = torch.exp(-1j * self.Y_[None, :, None] * self.y_positions[:, None, :]) #(batchsize, 2*kY, nParticle)
         if dim > 2:
             if z_pos_min is None:
@@ -49,7 +49,7 @@ class VandermondeTransformMatrixFree:
                                  torch.arange(start=-(self.kZ), end=0, dtype=dtype, device=device)),
                                  0)
             z_positions = z_positions - z_pos_min                          
-            self.z_positions = z_positions * 6.28 / z_pos_max             
+            self.z_positions = z_positions * 2*torch.pi / z_pos_max             
             self.Fz = torch.exp(-1j * self.Z_[None, :, None] * self.z_positions[:, None, :]) #(batchsize, 2*kZ, nParticle)
 
 

--- a/operator_learning/data/utils.py
+++ b/operator_learning/data/utils.py
@@ -130,6 +130,7 @@ def getDataLoaders(dataFile,
     print_rank0(f'Using GlobalBatchSize: {batchSize}, Gradient accumulation steps: {gas}, train localBatchSize: {train_batchSize}, validation localBatchSize: {valid_batchSize}')
     trainLoader = DataLoader(trainSet, batch_size=train_batchSize, sampler=train_sampler, shuffle=(train_sampler is None), 
                              num_workers=num_workers, persistent_workers=True, collate_fn=collate_fn, pin_memory=True)
-    valLoader = DataLoader(valSet, batch_size=valid_batchSize, sampler=val_sampler, shuffle=False, num_workers=num_workers, persistent_workers=True, collate_fn=collate_fn, pin_memory=True)
+    valLoader = DataLoader(valSet, batch_size=valid_batchSize, sampler=val_sampler, shuffle=False, 
+                            num_workers=num_workers, persistent_workers=True, collate_fn=collate_fn, pin_memory=True)
 
     return trainLoader, valLoader, dataset, train_sampler, val_sampler

--- a/operator_learning/layers/dse.py
+++ b/operator_learning/layers/dse.py
@@ -19,10 +19,6 @@ class SpectralConv_dse(nn.Module):
     def __init__(self, dv, kX, kY=None, kZ=None, dataClass='pic', bias=False, 
                  dim=1, use_complex_amp=False, tp_mesh=None, dtype=torch.complex64):
         
-        """
-        Spectral weights R and Bias must be kept in Float64 when particle 
-        sharding is  enabled.
-        """
         super().__init__()
         assert dim in (1,2, 3), "implemented only for PIC1D, PIC2D and PIC3D"
         self.dim = dim

--- a/operator_learning/layers/dse.py
+++ b/operator_learning/layers/dse.py
@@ -17,7 +17,7 @@ from operator_learning.utils.misc import (
 
 class SpectralConv_dse(nn.Module):
     def __init__(self, dv, kX, kY=None, kZ=None, dataClass='pic', bias=False, 
-                 dim=1, use_complex_amp=False, tp_mesh=None, dtype=torch.complex128):
+                 dim=1, use_complex_amp=False, tp_mesh=None, dtype=torch.complex64):
         
         """
         Spectral weights R and Bias must be kept in Float64 when particle 
@@ -32,6 +32,7 @@ class SpectralConv_dse(nn.Module):
         self.channel = dv
         self.use_complex_amp = use_complex_amp
         self.data_type = dtype
+        self.bias_dtype = torch.float32 if dtype == torch.complex64 else torch.float64
         self.scale = 1 / (dv * dv)
         self.tp_mesh = tp_mesh
         if self.tp_mesh is not None:
@@ -53,7 +54,7 @@ class SpectralConv_dse(nn.Module):
             init_std = (2/(dv * dim))**0.5
             self.bias = nn.Parameter(
                 init_std * torch.randn(*(tuple([dv]) + (1,)))
-            ).to(torch.float64)
+            ).to(self.bias_dtype)  
         else:
             self.bias = None
         
@@ -73,7 +74,7 @@ class SpectralConv_dse(nn.Module):
             R = deformat_complexTensor(weights.half()).to(input.device)  # complex32
         else:
             einsum_fn = torch.einsum
-            R = deformat_complexTensor(weights).to(input.device) # complex128
+            R = deformat_complexTensor(weights).to(input.device) # complex64/complex128
 
         if self.dim == 1:
             return einsum_fn("bik,iok->bok", input, R)
@@ -101,7 +102,7 @@ class SpectralConv_dse(nn.Module):
         # Transform to fourier space
         # Fourier coeffs (complex)
         x_ft = transform.forward(x.to(dtype))  # [batchsize, dv, modes]
-        x_ft = x_ft.contiguous()
+        # x_ft = x_ft.contiguous()
 
 
         # print(f'x_ft: {x_ft.dtype}', flush=True)
@@ -109,11 +110,11 @@ class SpectralConv_dse(nn.Module):
 
 
         if self.tp_size > 1:
-            # torch.distributed.all_reduce(x_ft, group=self.tp_mesh.get_group())
-            x_ft = torch.distributed.nn.functional.all_reduce(x_ft.contiguous(), 
-                                                    op=torch.distributed.ReduceOp.SUM,
-                                                    group=self.tp_mesh.get_group())
-            x_ft =  ContiguousGrad.apply(x_ft)
+            torch.distributed.all_reduce(x_ft, group=self.tp_mesh.get_group())
+            # x_ft = torch.distributed.nn.functional.all_reduce(x_ft.contiguous(), 
+            #                                         op=torch.distributed.ReduceOp.SUM,
+            #                                         group=self.tp_mesh.get_group())
+            # x_ft =  ContiguousGrad.apply(x_ft)
 
             # print(f'x_ft_after: {x_ft.dtype}', flush=True)
             # _dump_tensor("x_ft_after", x_ft)
@@ -159,7 +160,7 @@ class DSELayer(nn.Module):
                  dim=1,
                  use_complex_amp=False,
                  tp_mesh=None,
-                 dtype=torch.float64
+                 dtype=torch.float32
                  ):
         super().__init__()
 
@@ -170,12 +171,13 @@ class DSELayer(nn.Module):
             self.sigma = nn.ReLU(inplace=True)
         
         self.tp_mesh = tp_mesh
+        self.spectral_dtype = torch.complex128 if dtype == torch.float64 else torch.complex64
         self.conv = SpectralConv_dse(dv=dv, kX=kX, kY=kY, kZ=kZ, 
                                     dataClass=dataClass,
                                     bias=bias, dim=dim,
                                     use_complex_amp=use_complex_amp,
                                     tp_mesh=tp_mesh,
-                                    dtype=torch.complex128)
+                                    dtype=self.spectral_dtype)  
     
         # self.W = GridLinear(
         #                inSize=dv, outSize=dv, hiddenSize=None,

--- a/operator_learning/layers/dse.py
+++ b/operator_learning/layers/dse.py
@@ -1,17 +1,28 @@
-import os
+import os, sys
 import warnings
 if os.getenv("ENABLE_FLOP_WRAPPERS", "0") == "1":
     from operator_learning.utils import flop_wrappers
 import torch
 import torch.nn as nn
 from operator_learning.utils.communication import get_world_size, get_rank
-from operator_learning.utils.misc import format_complexTensor, deformat_complexTensor, einsum_complexhalf
 from .linear import GridLinear
 from .mlp import MLP
+from operator_learning.utils.misc import (
+    format_complexTensor,
+    deformat_complexTensor,
+    einsum_complexhalf,
+    _dump_tensor, 
+    ContiguousGrad
+)
 
 class SpectralConv_dse(nn.Module):
     def __init__(self, dv, kX, kY=None, kZ=None, dataClass='pic', bias=False, 
-                 dim=1, use_complex_amp=False, tp_mesh=None):
+                 dim=1, use_complex_amp=False, tp_mesh=None, dtype=torch.complex128):
+        
+        """
+        Spectral weights R and Bias must be kept in Float64 when particle 
+        sharding is  enabled.
+        """
         super().__init__()
         assert dim in (1,2, 3), "implemented only for PIC1D, PIC2D and PIC3D"
         self.dim = dim
@@ -20,6 +31,7 @@ class SpectralConv_dse(nn.Module):
         self.kZ = kZ if kZ is not None else kX
         self.channel = dv
         self.use_complex_amp = use_complex_amp
+        self.data_type = dtype
         self.scale = 1 / (dv * dv)
         self.tp_mesh = tp_mesh
         if self.tp_mesh is not None:
@@ -28,20 +40,20 @@ class SpectralConv_dse(nn.Module):
             self.tp_size = 1
       
         if dim == 1:
-            weights = self.scale * torch.rand(dv, dv, 2*self.kX, dtype=torch.cfloat)
+            weights = self.scale * torch.rand(dv, dv, 2*self.kX, dtype=self.data_type)
             self.R = nn.Parameter(format_complexTensor(weights))
         elif dim == 2:
-            weights = self.scale * torch.rand(dv, dv, 2*self.kX, 2*self.kY, dtype=torch.cfloat)
+            weights = self.scale * torch.rand(dv, dv, 2*self.kX, 2*self.kY, dtype=self.data_type)
             self.R = nn.Parameter(format_complexTensor(weights))
         else:
-            weights = self.scale * torch.rand(dv, dv, 2*self.kX, 2*self.kY, 2*self.kZ, dtype=torch.cfloat)
+            weights = self.scale * torch.rand(dv, dv, 2*self.kX, 2*self.kY, 2*self.kZ, dtype=self.data_type)
             self.R = nn.Parameter(format_complexTensor(weights))
 
         if bias:
             init_std = (2/(dv * dim))**0.5
             self.bias = nn.Parameter(
                 init_std * torch.randn(*(tuple([dv]) + (1,)))
-            )
+            ).to(torch.float64)
         else:
             self.bias = None
         
@@ -61,7 +73,7 @@ class SpectralConv_dse(nn.Module):
             R = deformat_complexTensor(weights.half()).to(input.device)  # complex32
         else:
             einsum_fn = torch.einsum
-            R = deformat_complexTensor(weights).to(input.device) # complex64
+            R = deformat_complexTensor(weights).to(input.device) # complex128
 
         if self.dim == 1:
             return einsum_fn("bik,iok->bok", input, R)
@@ -73,23 +85,39 @@ class SpectralConv_dse(nn.Module):
         
     def forward(self, x, transform):
         """
-        PIC1D/2D/3D:  x[batchsize, dv, nParticle], 
+        PIC 1D/2D/3D:  x[batchsize, dv, nParticle], 
         returns: [batchsize, dv, nParticle]
         """
 
         if self.training and self.use_complex_amp:
             dtype = torch.complex32 
         else:
-            dtype = torch.cfloat
-
+            dtype = self.data_type
         batchsize = x.shape[0]
+
+        # print(f'x: {x.dtype}, {dtype}', flush=True)
+        # _dump_tensor("x", x)
 
         # Transform to fourier space
         # Fourier coeffs (complex)
         x_ft = transform.forward(x.to(dtype))  # [batchsize, dv, modes]
-       
+        x_ft = x_ft.contiguous()
+
+
+        # print(f'x_ft: {x_ft.dtype}', flush=True)
+        # _dump_tensor("x_ft", x_ft)
+
+
         if self.tp_size > 1:
-            torch.distributed.all_reduce(x_ft, group=self.tp_mesh.get_group())
+            # torch.distributed.all_reduce(x_ft, group=self.tp_mesh.get_group())
+            x_ft = torch.distributed.nn.functional.all_reduce(x_ft.contiguous(), 
+                                                    op=torch.distributed.ReduceOp.SUM,
+                                                    group=self.tp_mesh.get_group())
+            x_ft =  ContiguousGrad.apply(x_ft)
+
+            # print(f'x_ft_after: {x_ft.dtype}', flush=True)
+            # _dump_tensor("x_ft_after", x_ft)
+
             
         if self.dim == 1:
             out_ft = self.compl_mul(x_ft, self.R)  # [batchsize, dv, kX]
@@ -101,13 +129,23 @@ class SpectralConv_dse(nn.Module):
             x_ft = torch.reshape(x_ft, (batchsize, self.channel, 2*self.kX, 2*self.kY, 2*self.kZ))  # [batchsize, dv, 2*kX, 2*kY, 2*kZ]
             out_ft = self.compl_mul(x_ft, self.R)
             out_ft = torch.reshape(out_ft, (batchsize, self.channel, 2*self.kX*(2*self.kY)*(2*self.kZ)))  # [batchsize, dv, modes]
-     
+        
+        # print(f"out_ft: {out_ft.dtype}", flush=True)
+        # _dump_tensor("out_ft", out_ft)
+
         # Return to physical space
         x  = transform.inverse(out_ft)   # [batchsize, dv, nParticle]
+       
+        # _dump_tensor("x_inv", x)
+        # print(f'x_inv: {x.dtype}', flush=True)
+
         x = (x / (x.size(-1) * self.tp_size)) * self.dim 
+        
+        # _dump_tensor("x_out", x)
 
         if self.bias is not None:
             x = x + self.bias
+        # _dump_tensor("x_bias", x)
 
         return x.real
 
@@ -121,6 +159,7 @@ class DSELayer(nn.Module):
                  dim=1,
                  use_complex_amp=False,
                  tp_mesh=None,
+                 dtype=torch.float64
                  ):
         super().__init__()
 
@@ -131,7 +170,12 @@ class DSELayer(nn.Module):
             self.sigma = nn.ReLU(inplace=True)
         
         self.tp_mesh = tp_mesh
-        self.conv = SpectralConv_dse(dv, kX, kY, kZ, dataClass, bias, dim, use_complex_amp, tp_mesh)
+        self.conv = SpectralConv_dse(dv=dv, kX=kX, kY=kY, kZ=kZ, 
+                                    dataClass=dataClass,
+                                    bias=bias, dim=dim,
+                                    use_complex_amp=use_complex_amp,
+                                    tp_mesh=tp_mesh,
+                                    dtype=torch.complex128)
     
         # self.W = GridLinear(
         #                inSize=dv, outSize=dv, hiddenSize=None,
@@ -139,12 +183,13 @@ class DSELayer(nn.Module):
         #                n_dims=1, 
         #                )
 
-        self.W = MLP( mode='channel',
-                        n_dims=1,
-                        n_layers=1,
-                        in_channels=dv,
-                        out_channels=dv,
-                        hidden_channels=None,
+        self.W = MLP(mode='channel',
+                     n_dims=1,
+                     n_layers=1,
+                     in_channels=dv,
+                     out_channels=dv,
+                     hidden_channels=None,
+                     dtype=dtype,   # Need float64 when particle sharding is enabled
                     )
  
     def forward(self, x, transform):
@@ -152,9 +197,15 @@ class DSELayer(nn.Module):
         PIC1D/2D/3D: x[batchsize, dv, nParticle]
         Returns: [batchsize, dv, nParticle]
         """
+        # _dump_tensor(f"x_init", x)
         v = self.conv(x, transform)
+        # _dump_tensor("v",v)
+
         w = self.W(x)
+        # _dump_tensor("w",w)
+
         o = self.sigma(v+w)
+        # _dump_tensor("o",o)
 
         return o
 

--- a/operator_learning/layers/mlp.py
+++ b/operator_learning/layers/mlp.py
@@ -4,6 +4,7 @@ if os.getenv("ENABLE_FLOP_WRAPPERS", "0") == "1":
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from operator_learning.utils.misc import _dump_tensor
 
 class MLP(nn.Module):
     """
@@ -35,6 +36,7 @@ class MLP(nn.Module):
                  n_dims=2,
                  non_linearity=nn.GELU(),
                  dropout=0.0,
+                 dtype=torch.float32,
                  **kwargs):
         super().__init__()
 
@@ -49,6 +51,7 @@ class MLP(nn.Module):
         self.hidden_channels = in_channels if hidden_channels is None else hidden_channels
         self.dropout = dropout
         self.non_linearity = non_linearity
+        self.dtype = dtype
 
         self.layers = nn.ModuleList()
         self.dropouts = nn.ModuleList()
@@ -61,20 +64,22 @@ class MLP(nn.Module):
 
             if mode == 'conv':
                 Conv = nn.Conv2d if n_dims == 2 else nn.Conv3d
-                layer = Conv(in_ch, out_ch, kernel_size=1)
+                layer = Conv(in_ch, out_ch, kernel_size=1, bias=True)
 
             elif mode == 'channel':
-                layer = nn.Conv1d(in_ch, out_ch, kernel_size=1)
+                layer = nn.Conv1d(in_ch, out_ch, kernel_size=1, bias=True)
 
             elif mode == 'linear':
-                layer = nn.Linear(in_ch, out_ch)
+                layer = nn.Linear(in_ch, out_ch, bias=True)
 
-            self.layers.append(layer)
-            self.dropouts.append(nn.Dropout(dropout) if dropout > 0 else nn.Identity())
+            self.layers.append(layer.to(self.dtype))
+            self.dropouts.append(nn.Dropout(dropout).to(self.dtype) if dropout > 0 else nn.Identity().to(self.dtype))
 
     def forward(self, x):
         reshaped = False
         original_shape = x.shape
+        if x.dtype is not self.dtype:
+            x = x.to(self.dtype)
 
         if self.mode == 'channel':
             if x.ndim > 3:
@@ -82,9 +87,14 @@ class MLP(nn.Module):
                 reshaped = True
 
         for i in range(self.n_layers):
+            # _dump_tensor(f"x_{self.mode}_{i}_init", x)
             x = self.layers[i](x)
+            # _dump_tensor(f"x_{self.mode}_{i}", x)
+
             if i < self.n_layers - 1:
                 x = self.non_linearity(x)
+                # _dump_tensor(f"x_act_{self.mode}_{i}",x)
+            
             x = self.dropouts[i](x)
 
         if self.mode == 'channel' and reshaped:

--- a/operator_learning/model/fno.py
+++ b/operator_learning/model/fno.py
@@ -109,6 +109,7 @@ class FNO(nn.Module):
                  matrix_free=False,
                  device='cpu',
                  dtype=torch.float32,
+                 fno_dtype=torch.float32,
                  **kwargs
                  ):
         
@@ -136,7 +137,7 @@ class FNO(nn.Module):
         self.data_type = torch.float16 if use_complex_amp and self.training else dtype  # For P & Q layers
         self.tp_mesh = kwargs.get("tp_mesh", None)
         self.matrix_free = matrix_free
-        self.fno_dtype = torch.float32 if use_dse else self.data_type
+        self.fno_dtype = fno_dtype
         print_rank0(f"Using {self.data_type} for P and Q layers and {self.fno_dtype} for DSE Layer")
 
         if use_dse:

--- a/operator_learning/model/fno.py
+++ b/operator_learning/model/fno.py
@@ -6,7 +6,7 @@ import torch.nn as nn
 import pandas as pd
 import torch.nn.functional
 from operator_learning.utils.memory_utils import CudaMemoryDebugger, format_mem
-from operator_learning.utils.misc import print_rank0
+from operator_learning.utils.misc import print_rank0, _dump_tensor
 from operator_learning.layers import SpectralConv, SkipConnection, GridLinear, MLP, DSELayer, NUFFTLayer
 from operator_learning.data.transforms.vandermonde import VandermondeTransform
 from operator_learning.data.transforms.vandermonde_matrix_free import VandermondeTransformMatrixFree
@@ -108,6 +108,7 @@ class FNO(nn.Module):
                  use_complex_amp=False,
                  matrix_free=False,
                  device='cpu',
+                 dtype=torch.float32,
                  **kwargs
                  ):
         
@@ -132,7 +133,7 @@ class FNO(nn.Module):
 
         self.dataClass = dataClass
         self.dataset = dataset if dataClass == 'rbc' else None
-        self.data_type = torch.float16 if use_complex_amp and self.training else torch.float32
+        self.data_type = torch.float16 if use_complex_amp and self.training else dtype
         self.tp_mesh = kwargs.get("tp_mesh", None)
         self.matrix_free = matrix_free
 
@@ -145,6 +146,7 @@ class FNO(nn.Module):
                           dim=n_dims,
                           use_complex_amp=use_complex_amp,
                           tp_mesh=self.tp_mesh,
+                          dtype=torch.float64,  # FP64 necessary for input sharding
                          )
                  for _ in range(n_layers)])
         # elif use_toeplitz:
@@ -185,19 +187,23 @@ class FNO(nn.Module):
                         in_channels=da,
                         out_channels=dv,
                         hidden_channels=round(dv*channel_mlp_expansion),
+                        dtype=self.data_type
                     )
-        self.Q = MLP( mode='linear',
+        self.Q = MLP(mode='linear',
                         n_dims=n_dims,
                         n_layers=2,
                         in_channels=dv,
                         out_channels=du,
                         hidden_channels=round(dv*channel_mlp_expansion),
+                        dtype=self.data_type
                     )
        
         self.memory = CudaMemoryDebugger(print_mem=True)
  
 
-    def forward(self, x):
+    def forward(self, x, x_pos_min=None, x_pos_max=None,
+                y_pos_min=None, y_pos_max=None,
+                z_pos_min=None, z_pos_max=None):
         """
         RBC2D/3D:
             x[batchsize, da, nX, nY, (nZ)] -> [batchsize, du, nX, nY, (nZ)] 
@@ -210,25 +216,31 @@ class FNO(nn.Module):
                 if self.matrix_free:
                     transform_coeff = VandermondeTransformMatrixFree(x_positions=x[:,0,:], 
                                                        kX=self.kX, 
+                                                       x_pos_min=x_pos_min,
+                                                       x_pos_max=x_pos_max,
                                                        dim=self.n_dims,
                                                        device=self.device,
-                                                       dtype=self.data_type
+                                                       dtype=torch.float64
                                                         )
                 else:
                     transform_coeff = VandermondeTransform(x_positions=x[:,0,:], 
                                                        kX=self.kX, 
                                                        dim=self.n_dims,
                                                        device=self.device,
-                                                       dtype=self.data_type)
+                                                       dtype=torch.float64)
             elif self.n_dims == 2:
                 if self.matrix_free:
                     transform_coeff = VandermondeTransformMatrixFree(x_positions=x[:,0,:], 
                                                        y_positions=x[:,1,:],
                                                        kX=self.kX, 
                                                        kY=self.kY,
+                                                       x_pos_min=x_pos_min,
+                                                       x_pos_max=x_pos_max,
+                                                       y_pos_min=y_pos_min,
+                                                       y_pos_max=y_pos_max,
                                                        dim=self.n_dims,
                                                        device=self.device,
-                                                       dtype=self.data_type)
+                                                       dtype=torch.float64)
                 else:
                     transform_coeff = VandermondeTransform(x_positions=x[:,0,:], 
                                                         y_positions=x[:,1,:],
@@ -236,7 +248,7 @@ class FNO(nn.Module):
                                                         kY=self.kY,
                                                         dim=self.n_dims,
                                                         device=self.device,
-                                                        dtype=self.data_type)
+                                                        dtype=torch.float64)
             else:
                 if self.matrix_free:
                     transform_coeff = VandermondeTransformMatrixFree(x_positions=x[:,0,:], 
@@ -245,9 +257,15 @@ class FNO(nn.Module):
                                                        kX=self.kX, 
                                                        kY=self.kY,
                                                        kZ=self.kZ,
+                                                       x_pos_min=x_pos_min,
+                                                       x_pos_max=x_pos_max,
+                                                       y_pos_min=y_pos_min,
+                                                       y_pos_max=y_pos_max,
+                                                       z_pos_min=z_pos_min,
+                                                       z_pos_max=z_pos_max,
                                                        dim=self.n_dims,
                                                        device=self.device,
-                                                       dtype=self.data_type)
+                                                       dtype=torch.float64)
                 else:
                     transform_coeff = VandermondeTransform(x_positions=x[:,0,:], 
                                                         y_positions=x[:,1,:],
@@ -257,7 +275,7 @@ class FNO(nn.Module):
                                                         kZ=self.kZ,
                                                         dim=self.n_dims,
                                                         device=self.device,
-                                                        dtype=self.data_type)
+                                                        dtype=torch.float64)
                 
 
         # if self.use_toeplitz:
@@ -267,25 +285,29 @@ class FNO(nn.Module):
         #                                      dim=self.n_dims, 
         #                                      dtype=self.data_type)
         
-        if self.use_kb:
-            transform_coeff = NUFFTTransform(device=self.device, 
-                                             dataClass='pic',
-                                             transform='kb', 
-                                             dim=self.n_dims, 
-                                             dtype=self.data_type)
+        # if self.use_kb:
+        #     transform_coeff = NUFFTTransform(device=self.device, 
+        #                                      dataClass='pic',
+        #                                      transform='kb', 
+        #                                      dim=self.n_dims, 
+        #                                      dtype=self.data_type)
 
+        if x.dtype is not self.data_type:
+            x = x.to(self.data_type)
 
         x = x.permute(0,2,1)
         x = self.P(x)
         x = x.permute(0,2,1)
+        # _dump_tensor("p", x)
 
         for index,layer in enumerate(self.layers):
             x = layer(x, transform_coeff)
+            # _dump_tensor(f"x_{index}",x)
           
         x = x.permute(0,2,1)
         x = self.Q(x)
         x = x.permute(0,2,1)
- 
+        # _dump_tensor("q", x)
 
         return x
 

--- a/operator_learning/model/fno.py
+++ b/operator_learning/model/fno.py
@@ -133,9 +133,11 @@ class FNO(nn.Module):
 
         self.dataClass = dataClass
         self.dataset = dataset if dataClass == 'rbc' else None
-        self.data_type = torch.float16 if use_complex_amp and self.training else dtype
+        self.data_type = torch.float16 if use_complex_amp and self.training else dtype  # For P & Q layers
         self.tp_mesh = kwargs.get("tp_mesh", None)
         self.matrix_free = matrix_free
+        self.fno_dtype = torch.float32 if use_dse else self.data_type
+        print_rank0(f"Using {self.data_type} for P and Q layers and {self.fno_dtype} for DSE Layer")
 
         if use_dse:
             self.layers = nn.ModuleList(
@@ -146,7 +148,7 @@ class FNO(nn.Module):
                           dim=n_dims,
                           use_complex_amp=use_complex_amp,
                           tp_mesh=self.tp_mesh,
-                          dtype=torch.float64,  # FP64 necessary for input sharding
+                          dtype=self.fno_dtype,  # FP64 necessary for input sharding
                          )
                  for _ in range(n_layers)])
         # elif use_toeplitz:
@@ -220,14 +222,14 @@ class FNO(nn.Module):
                                                        x_pos_max=x_pos_max,
                                                        dim=self.n_dims,
                                                        device=self.device,
-                                                       dtype=torch.float64
+                                                       dtype=self.fno_dtype
                                                         )
                 else:
                     transform_coeff = VandermondeTransform(x_positions=x[:,0,:], 
                                                        kX=self.kX, 
                                                        dim=self.n_dims,
                                                        device=self.device,
-                                                       dtype=torch.float64)
+                                                       dtype=self.fno_dtype)
             elif self.n_dims == 2:
                 if self.matrix_free:
                     transform_coeff = VandermondeTransformMatrixFree(x_positions=x[:,0,:], 
@@ -240,7 +242,7 @@ class FNO(nn.Module):
                                                        y_pos_max=y_pos_max,
                                                        dim=self.n_dims,
                                                        device=self.device,
-                                                       dtype=torch.float64)
+                                                       dtype=self.fno_dtype)
                 else:
                     transform_coeff = VandermondeTransform(x_positions=x[:,0,:], 
                                                         y_positions=x[:,1,:],
@@ -248,7 +250,7 @@ class FNO(nn.Module):
                                                         kY=self.kY,
                                                         dim=self.n_dims,
                                                         device=self.device,
-                                                        dtype=torch.float64)
+                                                        dtype=self.fno_dtype)
             else:
                 if self.matrix_free:
                     transform_coeff = VandermondeTransformMatrixFree(x_positions=x[:,0,:], 
@@ -265,7 +267,7 @@ class FNO(nn.Module):
                                                        z_pos_max=z_pos_max,
                                                        dim=self.n_dims,
                                                        device=self.device,
-                                                       dtype=torch.float64)
+                                                       dtype=self.fno_dtype)
                 else:
                     transform_coeff = VandermondeTransform(x_positions=x[:,0,:], 
                                                         y_positions=x[:,1,:],
@@ -275,7 +277,7 @@ class FNO(nn.Module):
                                                         kZ=self.kZ,
                                                         dim=self.n_dims,
                                                         device=self.device,
-                                                        dtype=torch.float64)
+                                                        dtype=self.fno_dtype)
                 
 
         # if self.use_toeplitz:

--- a/operator_learning/utils/misc.py
+++ b/operator_learning/utils/misc.py
@@ -210,7 +210,8 @@ def count_flops(
     y: torch.tensor,
     loss_fn: callable,
     device: torch.device,
-    dtp_group: dist.ProcessGroup
+    dtp_group: dist.ProcessGroup,
+    ddp_enabled: bool
 ):
     """
     Count floating point operations [TFLOP] in forward and backward pass of the model.
@@ -224,7 +225,8 @@ def count_flops(
             pred = model(x)
 
     forward_flops = torch.tensor(flop_counter.get_total_flops(), device=device)
-    dist.all_reduce(forward_flops, group=dtp_group)
+    if ddp_enabled:
+        dist.all_reduce(forward_flops, group=dtp_group)
 
     with FlopCounterMode(
         display=False
@@ -233,7 +235,8 @@ def count_flops(
         loss.backward()
 
     backward_flops = torch.tensor(flop_counter.get_total_flops(), device=device)
-    dist.all_reduce(backward_flops, group=dtp_group)
+    if ddp_enabled:
+        dist.all_reduce(backward_flops, group=dtp_group)
 
     with FlopCounterMode(
         display=False
@@ -243,7 +246,8 @@ def count_flops(
         loss.backward()
 
     total_flops = torch.tensor(flop_counter.get_total_flops(), device=device)
-    dist.all_reduce(total_flops, group=dtp_group)
+    if ddp_enabled:
+        dist.all_reduce(total_flops, group=dtp_group)
 
     # if dist.get_rank(group=dtp_group) == 0:
     #     print(f"Forward flops per iteration is {forward_flops / 1e12} TFLOP")
@@ -253,3 +257,37 @@ def count_flops(
     #     )
 
     return forward_flops, backward_flops, total_flops
+
+
+def _dump_tensor(name, t, log_dir="./debug_logs"):
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    os.makedirs(log_dir, exist_ok=True)
+    path = os.path.join(
+        log_dir,
+        f"rank{rank}_{name}.pt"
+    )
+    torch.save(t.detach().cpu(), path)
+
+def clone_state_dict(model):
+    return {
+        name: p.detach().cpu().clone()
+        for name, p in model.named_parameters()
+    }
+
+def clone_grads(model):
+    grads = {}
+    for name, p in model.named_parameters():
+        if p.grad is None:
+            grads[name] = None
+        else:
+            grads[name] = p.grad.detach().cpu().clone()
+    return grads
+
+class ContiguousGrad(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x):
+        return x
+
+    @staticmethod
+    def backward(ctx, grad):
+        return grad.contiguous()

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -31,6 +31,7 @@ python train.py --config config.yaml --epochs 50 --trainDir results/
 - `--benchmark` : To get benchmark matrices
 - `--use_amp` : To use mixed precision training (Float32/Float16)
 - `--use_complex_amp` : To use explicit casting of torch.complex64 to torch.complex32
+- `--model_dtype` : To set the dtype for layers other than FNO Layer(float64) to either float32 or float64
 - `--compile_train`: To compile `train()` with `torch.compile`
 - `--compile_mode` : `torch.compile` mode ['eager', 'default', 'reduce-overhead', 'max-autotune', 'max-autotune-no-cudagraphs']
 - `--measure_power`: To measure power and energy during training on GPU using [jpwr](https://github.com/FZJ-JSC/jpwr)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -31,7 +31,8 @@ python train.py --config config.yaml --epochs 50 --trainDir results/
 - `--benchmark` : To get benchmark matrices
 - `--use_amp` : To use mixed precision training (Float32/Float16)
 - `--use_complex_amp` : To use explicit casting of torch.complex64 to torch.complex32
-- `--model_dtype` : To set the dtype for layers other than FNO Layer(float64) to either float32 or float64
+- `--model_dtype` : To set the dtype for layers other than FNO-DSE Layer to either float32 or float64 (default: `float32`)
+- `--fno_dtype` : To set the dtype for FNO-DSE Layer to either float32 or float64 (default: `float32`)
 - `--compile_train`: To compile `train()` with `torch.compile`
 - `--compile_mode` : `torch.compile` mode ['eager', 'default', 'reduce-overhead', 'max-autotune', 'max-autotune-no-cudagraphs']
 - `--measure_power`: To measure power and energy during training on GPU using [jpwr](https://github.com/FZJ-JSC/jpwr)
@@ -101,6 +102,8 @@ OR
 - `--dim`: Dimension of the problem (default: 1)
 - `--alpha`: Pertubation (default: 0.5)
 - `--config`: Configuration file for evaluation parameters (default: None)  
+- `--model_dtype` : To set the dtype for layers other than FNO-DSE Layer to either float32 or float64 (default: `float32`)
+- `--fno_dtype` : To set the dtype for FNO-DSE Layer to either float32 or float64 (default: `float32`)
 
 
 # Benchmark

--- a/scripts/pic_eval/eval.py
+++ b/scripts/pic_eval/eval.py
@@ -66,107 +66,110 @@ if args.config is not None:
         args.checkpoint = config.train.checkpoint
         if "trainDir" in config.train:
             FourierNeuralOperator.TRAIN_DIR = config.train.trainDir
-
+    
 device = 'cuda' if torch.cuda.is_available() else 'cpu'
 device_name = torch.cuda.get_device_name(0) if device == 'cuda' else 'CPU'
 checkpoint = args.checkpoint
 dim = args.dim
 predOnly = args.predOnly
-testCase = args.testCase
-
 seed = 152
 torch.manual_seed(seed)
 np.random.seed(seed)
 cp.random.seed(seed)
 torch.cuda.manual_seed_all(seed)
-vis = PICVisualizer(args)
 
-if checkpoint is not None:
-    fno_model = FourierNeuralOperator(checkpoint=checkpoint, eval_only=True, device=device, data_class='pic')
-    posPred, velPred, wPred, EnergyPred, EkPred, EpPred, pPred, ExpPred, EypPred, EzpPred, timePred = vis.picND(ml_acc=True, model=fno_model, data_file=config.data.dataFile)
-    phase_spacePred = None
+for tc in config["testCases"]:
+    args.__dict__.update(**config["testCases"][tc])
+    args.evalDir = f"{config.eval.evalDir}/{tc}"
+    testCase = tc
+    vis = PICVisualizer(args)
 
-else:
-    EnergyPred = None
-    EkPred = None
-    EpPred = None
-    EPred = None
-    pPred = None
-    ExpPred = None
-    EypPred = None
-    EzpPred = None
-    timePred = None
-    phase_spacePred = None
-    growth_ratePred = None
-    speedup = 1
+    if checkpoint is not None:
+        fno_model = FourierNeuralOperator(checkpoint=checkpoint, eval_only=True, device=device, data_class='pic')
+        posPred, velPred, wPred, EnergyPred, EkPred, EpPred, pPred, ExpPred, EypPred, EzpPred, timePred = vis.picND(ml_acc=True, model=fno_model, data_file=config.data.dataFile)
+        phase_spacePred = None
 
-if predOnly is False:
-    posRef, velRef, wRef, EnergyRef, EkRef, EpRef, pRef, ExpRef, EypRef, EzpRef, timeRef = vis.picND(ml_acc=False)
-    phase_spaceRef = None
-else:
-    EnergyRef = None
-    EkRef = None
-    EpRef = None
-    ERef = None
-    pRef = None
-    ExpRef = None
-    EypRef = None
-    EzpRef = None
-    timeRef = None
-    phase_spaceRef = None
-    growth_rateRef = None
-    speedup = 1
+    else:
+        EnergyPred = None
+        EkPred = None
+        EpPred = None
+        EPred = None
+        pPred = None
+        ExpPred = None
+        EypPred = None
+        EzpPred = None
+        timePred = None
+        phase_spacePred = None
+        growth_ratePred = None
+        speedup = 1
 
-energy = vis.energy(ERef=EnergyRef, EPred=EnergyPred, EkRef=EkRef, EpRef=EpRef, EkPred=EkPred, EpPred=EpPred)
-conserv_error = vis.conservation_errors(ERef=EnergyRef, EPred=EnergyPred, pRef=pRef, pPred=pPred)
-if ((testCase == "weakLandau") or (testCase == "strongLandau")):
-    landau_decay = vis.landau_decay(Ex=ExpRef, ExPred=ExpPred, Ey=EypRef, EyPred=EypPred, Ez=EzpRef, EzPred=EzpPred, label=testCase)
-elif ((testCase == "tsi") or (testCase == "bti")):
-    growth_rate = vis.instability(Ex=ExpRef, ExPred=ExpPred, Ey=EypRef, EyPred=EypPred, Ez=EzpRef, EzPred=EzpPred, label=testCase)
+    if predOnly is False:
+        posRef, velRef, wRef, EnergyRef, EkRef, EpRef, pRef, ExpRef, EypRef, EzpRef, timeRef = vis.picND(ml_acc=False)
+        phase_spaceRef = None
+    else:
+        EnergyRef = None
+        EkRef = None
+        EpRef = None
+        ERef = None
+        pRef = None
+        ExpRef = None
+        EypRef = None
+        EzpRef = None
+        timeRef = None
+        phase_spaceRef = None
+        growth_rateRef = None
+        speedup = 1
 
-HEADER = """
-# FNO evaluation for PIC in {dim}D on {device}
-## Simulation Configuration
+    energy = vis.energy(ERef=EnergyRef, EPred=EnergyPred, EkRef=EkRef, EpRef=EpRef, EkPred=EkPred, EpPred=EpPred)
+    conserv_error = vis.conservation_errors(ERef=EnergyRef, EPred=EnergyPred, pRef=pRef, pPred=pPred)
+    if ((testCase == "weakLandau") or (testCase == "strongLandau")):
+        landau_decay = vis.landau_decay(Ex=ExpRef, ExPred=ExpPred, Ey=EypRef, EyPred=EypPred, Ez=EzpRef, EzPred=EzpPred, label=testCase)
+    elif ((testCase == "tsi") or (testCase == "bti")):
+        growth_rate = vis.instability(Ex=ExpRef, ExPred=ExpPred, Ey=EypRef, EyPred=EypPred, Ez=EzpRef, EzPred=EzpPred, label=testCase)
 
-| Parameter    | Value   |
-|--------------|---------|
-{rows}
-"""
+    HEADER = """
+    # FNO evaluation for PIC in {dim}D on {device}
+    ## Simulation Configuration
 
-# Convert dict into Markdown table rows
-rows = "\n".join([f"| {k:<12} | {v} |" for k, v in args.__dict__.items()])
+    | Parameter    | Value   |
+    |--------------|---------|
+    {rows}
+    """
+
+    # Convert dict into Markdown table rows
+    rows = "\n".join([f"| {k:<12} | {v} |" for k, v in args.__dict__.items()])
 
 
-op = os.path
-with open(op.dirname(op.abspath(op.realpath(__file__)))+"/eval_template.md") as f:
-    TEMPLATE = f.read()
+    op = os.path
+    with open(op.dirname(op.abspath(op.realpath(__file__)))+"/eval_template.md") as f:
+        TEMPLATE = f.read()
 
-summary = open(f"{args.evalDir}/eval_run{args.runId}.md", "w")
-summary.write(HEADER.format(dim=dim, device=device_name, rows=rows))
+    summary = open(f"{args.evalDir}/eval_run{args.runId}.md", "w")
+    summary.write(HEADER.format(dim=dim, device=device_name, rows=rows))
 
-if phase_spaceRef is not None:
-    TEMPLATE += f"- [Phase space Ref]({phase_spaceRef})\n"
-if phase_spacePred is not None:
-    TEMPLATE += f"- [Phase space Pred]({phase_spacePred})\n"
+    if phase_spaceRef is not None:
+        TEMPLATE += f"- [Phase space Ref]({phase_spaceRef})\n"
+    if phase_spacePred is not None:
+        TEMPLATE += f"- [Phase space Pred]({phase_spacePred})\n"
 
-TEMPLATE  += f"\nAverage time for Accleration per timestep in PIC (millisec): {timeRef}\n"
+    TEMPLATE  += f"\nAverage time for Accleration per timestep in PIC (millisec): {timeRef}\n"
 
-if timePred is not None and timeRef is not None:
-    speedup = round(timeRef/timePred,3)
-    TEMPLATE += f"Average Inference time for Accleration using FNO (millisec): {timePred}\n"
-    TEMPLATE += f"Speed up PIC/FNO: {speedup}\n"
-                
-summary.write(TEMPLATE.format(
-        dim=dim,
-        device=device,
-        energy=energy,
-        conserv_errors=conserv_error,
-        landau_decay=None,
-        phase_spaceRef=phase_spaceRef,
-        phase_spacePred=phase_spacePred,
-        growth_rate=None,
-        timeRef=timeRef,
-        timePred=timePred,
-        speedup=speedup
-        ))
-summary.close()
+    if timePred is not None and timeRef is not None:
+        speedup = round(timeRef/timePred,3)
+        TEMPLATE += f"Average Inference time for Accleration using FNO (millisec): {timePred}\n"
+        TEMPLATE += f"Speed up PIC/FNO: {speedup}\n"
+                    
+    summary.write(TEMPLATE.format(
+            dim=dim,
+            device=device,
+            energy=energy,
+            conserv_errors=conserv_error,
+            landau_decay=None,
+            phase_spaceRef=phase_spaceRef,
+            phase_spacePred=phase_spacePred,
+            growth_rate=None,
+            timeRef=timeRef,
+            timePred=timePred,
+            speedup=speedup
+            ))
+    summary.close()

--- a/scripts/pic_eval/eval.py
+++ b/scripts/pic_eval/eval.py
@@ -3,6 +3,7 @@
 import os
 import sys
 from pathlib import Path
+from textwrap import dedent
 base_path = Path(__file__).resolve().parents[2]
 sys.path.append(str(base_path))
 
@@ -126,15 +127,16 @@ for tc in config["testCases"]:
         landau_decay = vis.landau_decay(Ex=ExpRef, ExPred=ExpPred, Ey=EypRef, EyPred=EypPred, Ez=EzpRef, EzPred=EzpPred, label=args.testCase)
     elif ((args.testCase == "tsi") or (args.testCase == "bti")):
         growth_rate = vis.instability(Ex=ExpRef, ExPred=ExpPred, Ey=EypRef, EyPred=EypPred, Ez=EzpRef, EzPred=EzpPred, label=args.testCase)
-
-    HEADER = """
+    
+    HEADER = dedent("""
     # FNO evaluation for PIC in {dim}D on {device}
+
     ## Simulation Configuration
 
-    | Parameter    | Value   |
-    |--------------|---------|
+    | Parameter | Value |
+    |-----------|-------|
     {rows}
-    """
+    """)
 
     # Convert dict into Markdown table rows
     rows = "\n".join([f"| {k:<12} | {v} |" for k, v in args.__dict__.items()])

--- a/scripts/pic_eval/eval.py
+++ b/scripts/pic_eval/eval.py
@@ -81,7 +81,7 @@ torch.cuda.manual_seed_all(seed)
 for tc in config["testCases"]:
     args.__dict__.update(**config["testCases"][tc])
     args.evalDir = f"{config.eval.evalDir}/{tc}"
-    testCase = tc
+    args.testCase = tc
     vis = PICVisualizer(args)
 
     if checkpoint is not None:
@@ -122,10 +122,10 @@ for tc in config["testCases"]:
 
     energy = vis.energy(ERef=EnergyRef, EPred=EnergyPred, EkRef=EkRef, EpRef=EpRef, EkPred=EkPred, EpPred=EpPred)
     conserv_error = vis.conservation_errors(ERef=EnergyRef, EPred=EnergyPred, pRef=pRef, pPred=pPred)
-    if ((testCase == "weakLandau") or (testCase == "strongLandau")):
-        landau_decay = vis.landau_decay(Ex=ExpRef, ExPred=ExpPred, Ey=EypRef, EyPred=EypPred, Ez=EzpRef, EzPred=EzpPred, label=testCase)
-    elif ((testCase == "tsi") or (testCase == "bti")):
-        growth_rate = vis.instability(Ex=ExpRef, ExPred=ExpPred, Ey=EypRef, EyPred=EypPred, Ez=EzpRef, EzPred=EzpPred, label=testCase)
+    if ((args.testCase == "weakLandau") or (args.testCase == "strongLandau")):
+        landau_decay = vis.landau_decay(Ex=ExpRef, ExPred=ExpPred, Ey=EypRef, EyPred=EypPred, Ez=EzpRef, EzPred=EzpPred, label=args.testCase)
+    elif ((args.testCase == "tsi") or (args.testCase == "bti")):
+        growth_rate = vis.instability(Ex=ExpRef, ExPred=ExpPred, Ey=EypRef, EyPred=EypPred, Ez=EzpRef, EzPred=EzpPred, label=args.testCase)
 
     HEADER = """
     # FNO evaluation for PIC in {dim}D on {device}

--- a/scripts/pic_eval/eval.py
+++ b/scripts/pic_eval/eval.py
@@ -56,7 +56,10 @@ parser.add_argument(
     "--ref", default="pic", help="Choose the reference numerical scheme pic or pif")
 parser.add_argument(
     "--model_dtype", type=str, default="float32", 
-    help="Model dtype for layers except FNO_DSE layer kept in float64, options['float32', 'float64'] ")
+    help="Model dtype for layers except FNO_DSE layer, options['float32', 'float64'] ")
+parser.add_argument(
+    "--fno_dtype", type=str, default="float32", 
+    help="FNO_DSE Layer dtype, options['float32', 'float64'] ")
 parser.add_argument(
     "--config", default=None, help="configuration file")
 args = parser.parse_args()
@@ -74,6 +77,10 @@ if args.model_dtype == 'float32':
     model_dtype = torch.float32
 else:
     model_dtype = torch.float64
+if args.fno_dtype == 'float32':
+    fno_dtype = torch.float32
+else:
+    fno_dtype = torch.float64
 device = 'cuda' if torch.cuda.is_available() else 'cpu'
 device_name = torch.cuda.get_device_name(0) if device == 'cuda' else 'CPU'
 checkpoint = args.checkpoint
@@ -92,7 +99,7 @@ for tc in config["testCases"]:
     vis = PICVisualizer(args)
 
     if checkpoint is not None:
-        fno_model = FourierNeuralOperator(checkpoint=checkpoint, eval_only=True, device=device, data_class='pic', model_dtype=model_dtype)
+        fno_model = FourierNeuralOperator(checkpoint=checkpoint, eval_only=True, device=device, data_class='pic', model_dtype=model_dtype, fno_dtype=fno_dtype)
         posPred, velPred, wPred, EnergyPred, EkPred, EpPred, pPred, ExpPred, EypPred, EzpPred, timePred = vis.picND(ml_acc=True, model=fno_model, data_file=config.data.dataFile)
         phase_spacePred = None
 

--- a/scripts/pic_eval/eval.py
+++ b/scripts/pic_eval/eval.py
@@ -55,6 +55,9 @@ parser.add_argument(
 parser.add_argument(
     "--ref", default="pic", help="Choose the reference numerical scheme pic or pif")
 parser.add_argument(
+    "--model_dtype", type=str, default="float32", 
+    help="Model dtype for layers except FNO_DSE layer kept in float64, options['float32', 'float64'] ")
+parser.add_argument(
     "--config", default=None, help="configuration file")
 args = parser.parse_args()
 
@@ -67,7 +70,10 @@ if args.config is not None:
         args.checkpoint = config.train.checkpoint
         if "trainDir" in config.train:
             FourierNeuralOperator.TRAIN_DIR = config.train.trainDir
-    
+if args.model_dtype == 'float32':
+    model_dtype = torch.float32
+else:
+    model_dtype = torch.float64
 device = 'cuda' if torch.cuda.is_available() else 'cpu'
 device_name = torch.cuda.get_device_name(0) if device == 'cuda' else 'CPU'
 checkpoint = args.checkpoint
@@ -86,7 +92,7 @@ for tc in config["testCases"]:
     vis = PICVisualizer(args)
 
     if checkpoint is not None:
-        fno_model = FourierNeuralOperator(checkpoint=checkpoint, eval_only=True, device=device, data_class='pic')
+        fno_model = FourierNeuralOperator(checkpoint=checkpoint, eval_only=True, device=device, data_class='pic', model_dtype=model_dtype)
         posPred, velPred, wPred, EnergyPred, EkPred, EpPred, pPred, ExpPred, EypPred, EzpPred, timePred = vis.picND(ml_acc=True, model=fno_model, data_file=config.data.dataFile)
         phase_spacePred = None
 

--- a/scripts/pic_eval/pic_plotter.py
+++ b/scripts/pic_eval/pic_plotter.py
@@ -5,6 +5,7 @@ sys.path.append(str(base_path))
 import numpy as np
 import cupy as cp
 import time
+from tqdm import tqdm
 from scipy import sparse
 import matplotlib.pyplot as plt
 import h5py
@@ -76,14 +77,16 @@ class PICVisualizer:
             "font.size": 12,
             "axes.labelsize": 12,
             "axes.titlesize": 14,
-            "legend.fontsize": 8,
+            "legend.fontsize": 6,
+            "legend.loc": "best",
+            "legend.labelspacing": 0.3,
             "lines.linewidth": 2,
             "grid.alpha": 0.4,
             "grid.linestyle": "--"
         })
 
     def _img_path(self, name: str) -> Path:
-        filename = f"{name}_run{self.args.runId}.{self.args.imgExt}"
+        filename = f"{self.testCase}_{name}_run{self.args.runId}.{self.args.imgExt}"
         return filename
 
 
@@ -153,9 +156,8 @@ class PICVisualizer:
             T2 = None
 
 
-        for it in range(self.NT):
+        for it in tqdm(range(self.NT)):
            
-            print(it)
             if(self.testCase != 'cyclotron'):
                 #Apply periodic BCs 
                 xp = toPeriodicND(x=xp, L=self.Ln, dim=self.dim)

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -47,7 +47,10 @@ parser.add_argument(
     help="compile options ['eager', 'default', 'reduce-overhead', 'max-autotune', 'max-autotune-no-cudagraphs']")
 parser.add_argument(
     "--model_dtype", type=str, default="float32", 
-    help="Model dtype for layers except FNO_DSE layer kept in float64, options['float32', 'float64'] ")
+    help="Model dtype for layers except FNO_DSE layer, options['float32', 'float64'] ")
+parser.add_argument(
+    "--fno_dtype", type=str, default="float32", 
+    help="FNO_DSE Layer dtype, options['float32', 'float64'] ")
 parser.add_argument(
     "--measure_power", type=int, default=0, help="use jpwr for power measurement during training [0:False, 1:True]")
 parser.add_argument(
@@ -100,6 +103,10 @@ def main(args):
         model_dtype = torch.float32
     else:
         model_dtype = torch.float64
+    if args.fno_dtype == 'float32':
+        fno_dtype = torch.float32
+    else:
+        fno_dtype = torch.float64
 
     if benchmark:
         print_rank0('Running FNO training for benchmarking...')
@@ -116,7 +123,8 @@ def main(args):
 
     model = FourierNeuralOperator(**configs, checkpoint=args.checkpoint, debug=False,\
                                 benchmark=benchmark, use_amp=use_amp, use_complex_amp=use_complex_amp, \
-                                compile=compile, compile_mode=compile_mode, model_dtype=model_dtype)
+                                compile=compile, compile_mode=compile_mode, model_dtype=model_dtype,
+                                fno_dtype=fno_dtype)
     model.learn(args.epochs, args.saveInterval)
 
     if torch.distributed.is_initialized():

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -114,7 +114,7 @@ def main(args):
     if measure_power:
         print_rank0('Measuring power usage during training using jpwr..')
 
-    model = FourierNeuralOperator(**configs, checkpoint=args.checkpoint, debug=True,\
+    model = FourierNeuralOperator(**configs, checkpoint=args.checkpoint, debug=False,\
                                 benchmark=benchmark, use_amp=use_amp, use_complex_amp=use_complex_amp, \
                                 compile=compile, compile_mode=compile_mode, model_dtype=model_dtype)
     model.learn(args.epochs, args.saveInterval)

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -46,6 +46,9 @@ parser.add_argument(
     "--compile_mode", type=str, default="default", 
     help="compile options ['eager', 'default', 'reduce-overhead', 'max-autotune', 'max-autotune-no-cudagraphs']")
 parser.add_argument(
+    "--model_dtype", type=str, default="float32", 
+    help="Model dtype for layers except FNO_DSE layer kept in float64, options['float32', 'float64'] ")
+parser.add_argument(
     "--measure_power", type=int, default=0, help="use jpwr for power measurement during training [0:False, 1:True]")
 parser.add_argument(
     "--batchSize", type=int, help="training global batch size")
@@ -93,6 +96,10 @@ def main(args):
     use_complex_amp = True if args.use_complex_amp == 1 else False
     compile = True if args.compile_train == 1 else False
     compile_mode = args.compile_mode
+    if args.model_dtype == 'float32':
+        model_dtype = torch.float32
+    else:
+        model_dtype = torch.float64
 
     if benchmark:
         print_rank0('Running FNO training for benchmarking...')
@@ -107,9 +114,9 @@ def main(args):
     if measure_power:
         print_rank0('Measuring power usage during training using jpwr..')
 
-    model = FourierNeuralOperator(**configs, checkpoint=args.checkpoint, debug=False,\
+    model = FourierNeuralOperator(**configs, checkpoint=args.checkpoint, debug=True,\
                                 benchmark=benchmark, use_amp=use_amp, use_complex_amp=use_complex_amp, \
-                                compile=compile, compile_mode=compile_mode)
+                                compile=compile, compile_mode=compile_mode, model_dtype=model_dtype)
     model.learn(args.epochs, args.saveInterval)
 
     if torch.distributed.is_initialized():

--- a/training/train_fno.py
+++ b/training/train_fno.py
@@ -40,7 +40,8 @@ class FourierNeuralOperator:
                 lr_scheduler:dict=None, parallel_strategy:dict=None,
                 loss:dict=None, profile:dict=None, checkpoint=None,
                 eval_only=False, debug=False, device=None, benchmark=False, use_complex_amp=False,
-                use_amp=False, compile=False, compile_mode='default', data_class='pic', model_dtype=torch.float32):
+                use_amp=False, compile=False, compile_mode='default', data_class='pic', 
+                model_dtype=torch.float32, fno_dtype=torch.float32):
 
         if device is None:
             self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
@@ -50,7 +51,8 @@ class FourierNeuralOperator:
         self.world_size = int(os.getenv('WORLD_SIZE', '1'))
         self.debug = debug
         self.benchmark = benchmark
-        self.model_dtype = model_dtype   # FNO_DSE layer is kept in float64, choose float32 or float64 for other layers
+        self.fno_dtype = fno_dtype
+        self.model_dtype = model_dtype   # FNO_DSE layer is kept in fno_dtype choose float32 or float64 for other layers
         self.use_amp = use_amp
         self.use_complex_amp = use_complex_amp  # explicit casting to Float16 for complex numbers
         assert not (use_complex_amp and not use_amp), "use_complex_amp=True requires use_amp=True"
@@ -217,9 +219,10 @@ class FourierNeuralOperator:
     # Setup and utility methods
     # -------------------------------------------------------------------------
     def setupModel(self, model_config):
-        self.model = FNO(**model_config, dataset=self.dataset, dataClass=self.dataClass,\
+        self.model = FNO(**model_config, dataset=self.dataset, dataClass=self.dataClass,
                           use_complex_amp=self.use_complex_amp, device=self.device, 
-                          tp_mesh=self.tp_mesh, dtype=self.model_dtype).to(self.device)
+                          tp_mesh=self.tp_mesh, dtype=self.model_dtype, 
+                          fno_dtype=self.fno_dtype).to(self.device)
 
         # hooks = register_dtype_hooks(self.model)
         self.modelConfig = model_config.copy()

--- a/training/train_fno.py
+++ b/training/train_fno.py
@@ -549,6 +549,16 @@ class FourierNeuralOperator:
                     data = (inp_list[iBatch], out_list[iBatch])
                 else:
                     data = next(data_iter)
+                    dim = data[0].shape[1]
+                    x_pos_min, x_pos_max = torch.min(data[0][:, 0, :]), torch.max(data[0][:, 0, :])
+                    if dim > 1:
+                        y_pos_min, y_pos_max =  torch.min(data[0][:, 1, :]), torch.max(data[0][:, 1, :])
+                    else:
+                        y_pos_min, y_pos_max = None, None
+                    if dim > 2:
+                        z_pos_min, z_pos_max =  torch.min(data[0][:, 2, :]), torch.max(data[0][:, 2, :])
+                    else:
+                        z_pos_min, z_pos_max = None, None
                 if self.dataClass == 'pic':
                     # sharding particles across tp ranks
                     if self.TP_enabled:
@@ -567,7 +577,11 @@ class FourierNeuralOperator:
                     inp = data[0][..., ::self.xStep, ::self.yStep].to(self.device)
                     ref = data[1][..., ::self.xStep, ::self.yStep].to(self.device)
 
-                pred = model(inp)
+                pred = model(inp,
+                            x_pos_min=x_pos_min, x_pos_max=x_pos_max,
+                            y_pos_min=y_pos_min, y_pos_max=y_pos_max, 
+                            z_pos_min=z_pos_min, z_pos_max=z_pos_max
+                            )
                 local_loss = self.lossFunction(pred,ref)
                 error_nr = torch.mean(torch.abs(ref.flatten(start_dim=1) - pred.flatten(start_dim=1)))
                 error_dr = torch.mean(torch.abs(ref.flatten(start_dim=1)))

--- a/training/train_fno.py
+++ b/training/train_fno.py
@@ -15,7 +15,7 @@ import torch.cuda.nvtx as nvtx
 from operator_learning.data import getDataLoaders
 from operator_learning.model import FNO
 from operator_learning.loss import LOSSES_CLASSES
-from operator_learning.utils.communication import Communicator
+from operator_learning.utils.communication import Communicator, get_rank
 from operator_learning.utils.misc import (
     print_rank0,
     NoScale,
@@ -24,7 +24,10 @@ from operator_learning.utils.misc import (
     scheduler_step,
     register_dtype_hooks,
     enable_tf32_only_on_a100,
-    count_flops
+    count_flops,
+    clone_grads,
+    clone_state_dict,
+    _dump_tensor
 )
 
 class FourierNeuralOperator:
@@ -37,7 +40,7 @@ class FourierNeuralOperator:
                 lr_scheduler:dict=None, parallel_strategy:dict=None,
                 loss:dict=None, profile:dict=None, checkpoint=None,
                 eval_only=False, debug=False, device=None, benchmark=False, use_complex_amp=False,
-                use_amp=False, compile=False, compile_mode='default', data_class='pic'):
+                use_amp=False, compile=False, compile_mode='default', data_class='pic', model_dtype=torch.float32):
 
         if device is None:
             self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
@@ -47,6 +50,7 @@ class FourierNeuralOperator:
         self.world_size = int(os.getenv('WORLD_SIZE', '1'))
         self.debug = debug
         self.benchmark = benchmark
+        self.model_dtype = model_dtype   # FNO_DSE layer is kept in float64, choose float32 or float64 for other layers
         self.use_amp = use_amp
         self.use_complex_amp = use_complex_amp  # explicit casting to Float16 for complex numbers
         assert not (use_complex_amp and not use_amp), "use_complex_amp=True requires use_amp=True"
@@ -214,7 +218,8 @@ class FourierNeuralOperator:
     # -------------------------------------------------------------------------
     def setupModel(self, model_config):
         self.model = FNO(**model_config, dataset=self.dataset, dataClass=self.dataClass,\
-                          use_complex_amp=self.use_complex_amp, device=self.device, tp_mesh=self.tp_mesh).to(self.device)
+                          use_complex_amp=self.use_complex_amp, device=self.device, 
+                          tp_mesh=self.tp_mesh, dtype=self.model_dtype).to(self.device)
 
         # hooks = register_dtype_hooks(self.model)
         self.modelConfig = model_config.copy()
@@ -246,7 +251,7 @@ class FourierNeuralOperator:
 
     def setupLRScheduler(self,lr_scheduler=None):
         if lr_scheduler is None:
-            lr_scheduler = {"scheduler": "StepLR", "step_size": 100.0, "gamma": 0.98}
+            lr_scheduler = {"scheduler": "ConstantLR", "factor": 1.0, "total_iters": 10**12}
         self.scheduler_config = lr_scheduler.copy()
         scheduler = self.scheduler_config.pop('scheduler')
         self.scheduler_name = scheduler
@@ -254,6 +259,8 @@ class FourierNeuralOperator:
             self.lr_scheduler = torch.optim.lr_scheduler.StepLR(self.optimizer, **self.scheduler_config)
         elif scheduler == "CosAnnealingLR":
             self.lr_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(self.optimizer, **self.scheduler_config)
+        elif scheduler == 'ConstantLR':
+            self.lr_scheduler = torch.optim.lr_scheduler.ConstantLR(self.optimizer, **self.scheduler_config)
         else:
             raise ValueError(f"LR scheduler {scheduler} not implemented yet")
 
@@ -327,6 +334,16 @@ class FourierNeuralOperator:
                     data = (inp_list[iBatch], out_list[iBatch])
                 else:
                     data = next(data_iter)
+                    dim = data[0].shape[1]
+                    x_pos_min, x_pos_max = torch.min(data[0][:, 0, :]), torch.max(data[0][:, 0, :])
+                    if dim > 1:
+                        y_pos_min, y_pos_max =  torch.min(data[0][:, 1, :]), torch.max(data[0][:, 1, :])
+                    else:
+                        y_pos_min, y_pos_max = None, None
+                    if dim > 2:
+                        z_pos_min, z_pos_max =  torch.min(data[0][:, 2, :]), torch.max(data[0][:, 2, :])
+                    else:
+                        z_pos_min, z_pos_max = None, None
                 if self.dataClass == 'pic':
                     # sharding particles across tp ranks
                     if self.TP_enabled:
@@ -345,20 +362,28 @@ class FourierNeuralOperator:
                     inp = data[0][..., ::self.xStep, ::self.yStep].to(self.device)
                     ref = data[1][..., ::self.xStep, ::self.yStep].to(self.device)
 
-                if iBatch == 0:
+                if self.benchmark and iBatch == 0:
                     forward_flops, backward_flops, total_flops = count_flops(
                                                             model=model,
                                                             x=inp,
                                                             y=ref,
                                                             loss_fn=self.lossFunction,
                                                             device=self.device,
-                                                            dtp_group=None
+                                                            dtp_group=None,
+                                                            ddp_enabled=self.DDP_enabled
                                                         )
+                
+                if self.debug:
+                    param_before = clone_state_dict(model)
 
                 # Forward pass
                 if self.enable_profile:
                     nvtx.range_push("forward")
-                pred = model(inp)
+                pred = model(inp,
+                            x_pos_min=x_pos_min, x_pos_max=x_pos_max,
+                            y_pos_min=y_pos_min, y_pos_max=y_pos_max, 
+                            z_pos_min=z_pos_min, z_pos_max=z_pos_max
+                            )
                 if self.enable_profile:
                     nvtx.range_pop()   # end forward
     
@@ -407,22 +432,7 @@ class FourierNeuralOperator:
             #             dist.all_reduce(param.grad, group=self.tp_mesh.get_group())
             #             param.grad /= self.tp_size
 
-            if self.debug:
-                any_grad_nonzero = False
-                for name, p in self.model.named_parameters():
-                    if p.grad is not None and p.grad.abs().sum() > 0:
-                        any_grad_nonzero = True
-                        break
-                print_rank0(f"[DEBUG] Any nonzero gradients: {any_grad_nonzero}")
-                for name, param in self.model.named_parameters():
-                    if param.grad is None:
-                        print_rank0(f"[DEBUG] {name} has no gradient")
-                    else:
-                        print_rank0(f"[DEBUG] {name} grad mean: {param.grad.mean().item():.6e}")
-
-                real_model = self.model.module if self.DDP_enabled else self.model
-                param_before = real_model.P.layers[0].weight.clone()
-
+            
             # Optimizer
             if self.enable_profile:
                 nvtx.range_push("optimizer_step")
@@ -430,6 +440,21 @@ class FourierNeuralOperator:
                 optimizer_step(self.scaler, optimizer)
             if self.enable_profile:
                 nvtx.range_pop() # end optimizer
+
+            if self.debug:
+                grads_debug = clone_grads(model)
+                param_after = clone_state_dict(model)
+                torch.save(
+                    {
+                        "input": inp.detach().cpu(),
+                        "target": ref.detach().cpu(),
+                        "output": pred.detach().cpu(),
+                        "loss": loss.detach().cpu(),
+                        "params_before": param_before,
+                        "grads": grads_debug,
+                        "params_after": param_after,
+                }, self.fullPath('debugger.pt')
+            )
 
             if self.benchmark and iBatch % 10 == 0:
                 allocated = torch.cuda.memory_allocated() / (1024 ** 2)  # MB
@@ -440,24 +465,6 @@ class FourierNeuralOperator:
             if self.enable_profile:
                 if self.profiler_type == "torch":
                     self.profiler.step()
-
-            if self.debug:
-                param_after = real_model.P.layers[0].weight
-                print_rank0(f"Param changed: {not torch.allclose(param_before, param_after)}")
-                param_change = (param_before - param_after).norm().item()
-                print_rank0(f"[DEBUG] Parameter change norm: {param_change:.6e}")
-                # check if params update + optimizer states populated
-                with torch.no_grad():
-                    first_param = next(model.parameters())
-                    print_rank0(f"[DEBUG][train] Param[0] value sample: {first_param.view(-1)[0].item():.6e}")
-                opt_state = optimizer.state_dict()
-                if opt_state["state"]:
-                    first_state = next(iter(opt_state["state"].values()))
-                    for k, v in first_state.items():
-                        if isinstance(v, torch.Tensor):
-                            print_rank0(f"[DEBUG][train] Optimizer state {k}: mean={v.float().mean().item():.6e}")
-                else:
-                    print_rank0("[DEBUG][train] Optimizer state is EMPTY after step()!")
 
             grads = torch.cat([p.grad.flatten() for p in model.parameters() if p.grad is not None])
             grad_norm = grads.norm()
@@ -508,8 +515,11 @@ class FourierNeuralOperator:
             nvtx.range_pop() # end epoch
 
         print_rank0(
-                f"Train Epoch {self.epochs} time [min]: {(end_epoch_time - start_epoch_time) / 60.0}, average TFLOPs = {total_flops * nBatches / (end_epoch_time - start_epoch_time) / 1e12}"
-            )
+                f"Train Epoch {self.epochs} time [min]: {(end_epoch_time - start_epoch_time) / 60.0}")
+        if self.benchmark:
+            print_rank0(
+                    f"average TFLOPs = {total_flops * nBatches / (end_epoch_time - start_epoch_time) / 1e12}"
+                )
 
     def valid(self):
         model = self.model.eval()
@@ -809,9 +819,6 @@ class FourierNeuralOperator:
             "lr_scheduler_state_dict": self.lr_scheduler.state_dict(),
             }
 
-        if self.debug:
-            #  verify optimizer state saved
-            print_rank0(f"[DEBUG][save] Saving optimizer with {len(self.optimizer.state_dict()['state'])} entries")
 
         if self.rank == 0:
             torch.save(checkpoint, path)
@@ -841,7 +848,7 @@ class FourierNeuralOperator:
                 name = k if k.startswith('module.') else 'module.' + k
             else:
                 name = k[7:] if k.startswith('module.') else k
-            if v.dtype == torch.complex64:
+            if torch.is_complex(v):
                 new_state_dict[name] = torch.view_as_real(v)
             else:
                 new_state_dict[name] = v
@@ -870,16 +877,6 @@ class FourierNeuralOperator:
             self.setupLRScheduler({"scheduler": checkpoint['lr_scheduler']}.update(checkpoint['lr_scheduler_state_dict']))
             self.lr_scheduler.load_state_dict(checkpoint["lr_scheduler_state_dict"])
 
-            if self.debug:
-                # inspect optimizer state after load
-                opt_state = self.optimizer.state_dict()
-                print_rank0(f"[DEBUG][load] Loaded optimizer with {len(opt_state['state'])} entries")
-                for k, v in opt_state["state"].items():
-                    for name, t in v.items():
-                        if isinstance(t, torch.Tensor):
-                            print_rank0(f"[DEBUG][load] Param {k} - {name}: device={t.device}, mean={t.float().mean().item():.6e}")
-
-
         # waiting for all ranks to load checkpoint
         if self.DDP_enabled:
             dist.barrier()
@@ -896,7 +893,7 @@ class FourierNeuralOperator:
     # Inference method
     # -------------------------------------------------------------------------
     def __call__(self, u0, nEval=1):
-        enable_tf32_only_on_a100()
+        # enable_tf32_only_on_a100()
         model = self.model.eval()
         inpt = torch.tensor(u0, device=self.device, dtype=torch.get_default_dtype())
 
@@ -909,5 +906,8 @@ class FourierNeuralOperator:
                 inpt = outp
 
         # u1 = outp.cpu().detach().numpy()
-        u1 = cp.from_dlpack(outp.detach())
+        if outp.is_cuda:
+            u1 = cp.from_dlpack(outp.detach())
+        else:
+            u1 = cp.array(outp.detach().numpy())  # CPU eval
         return u1


### PR DESCRIPTION
This PR fixes the following:
- Make single eval run all mini-app configs
- For the Vandermonde matrix formation, when doing TP>1 the matrix was normalized using local min/max positions (meaning current slice of particles min and max, which is not always same as min and max of full particles) this was creating deviations so changed it to global min and max normalization.
- Implemented possibility of specifying Float64 and Float32 precision for P & Q layers and FNO_DSE layer (including VandermondeTransformMatrixFree)